### PR TITLE
Update Regex.init to allow optionally passing NSRegularExpression.Options

### DIFF
--- a/SwiftExpression/SwiftExpression/Regex.swift
+++ b/SwiftExpression/SwiftExpression/Regex.swift
@@ -22,7 +22,7 @@ public struct Regex {
      */
     public init?(pattern: String, options: NSRegularExpression.Options = []) {
         do {
-            self.regexPattern = try NSRegularExpression(pattern: pattern, options: [])
+            self.regexPattern = try NSRegularExpression(pattern: pattern, options: options)
         } catch {
             return nil
         }

--- a/SwiftExpression/SwiftExpression/Regex.swift
+++ b/SwiftExpression/SwiftExpression/Regex.swift
@@ -20,7 +20,7 @@ public struct Regex {
      
      - parameter pattern: The regular expression pattern
      */
-    public init?(pattern: String) {
+    public init?(pattern: String, options: NSRegularExpression.Options = []) {
         do {
             self.regexPattern = try NSRegularExpression(pattern: pattern, options: [])
         } catch {


### PR DESCRIPTION
This allows the regex to be set to case insensitive etc. As the NSRegularExpression is private, I don't think there is any other way to get to these options. 

The parameter is not required so this should not affect any existing code